### PR TITLE
Make header filters presence configurable.

### DIFF
--- a/dss-plugin-visual-edit/python-lib/tabulator_utils.py
+++ b/dss-plugin-visual-edit/python-lib/tabulator_utils.py
@@ -265,7 +265,7 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
     return t_col
 
 
-def get_columns_tabulator(de, freeze_editable_columns=False):
+def get_columns_tabulator(de, show_header_filter=True, freeze_editable_columns=False):
     """Prepare column settings to pass to Tabulator"""
 
     linked_record_names = []
@@ -284,7 +284,7 @@ def get_columns_tabulator(de, freeze_editable_columns=False):
         t_col = {
             "field": col_name,
             "title": col_name,
-            "headerFilter": True,
+            "headerFilter": show_header_filter,
             "resizable": True,
             "headerContextMenu": __ns__("headerMenu"),
         }

--- a/dss-plugin-visual-edit/python-lib/webapp/config/loader.py
+++ b/dss-plugin-visual-edit/python-lib/webapp/config/loader.py
@@ -35,6 +35,7 @@ class WebAppConfig:
         self.original_ds_name = typed_config.original_dataset
         self.primary_keys = typed_config.primary_keys
         self.editable_column_names = typed_config.editable_column_names
+        self.show_header_filter = typed_config.show_header_filter
         self.freeze_editable_columns = typed_config.freeze_editable_columns
         self.group_column_names = typed_config.group_column_names
         self.linked_records_count = typed_config.linked_records_count

--- a/dss-plugin-visual-edit/python-lib/webapp/config/models.py
+++ b/dss-plugin-visual-edit/python-lib/webapp/config/models.py
@@ -36,6 +36,7 @@ class Config(BaseModel):
     original_dataset: str = ""  # may be set by an environment variable
     primary_keys: List[str]
     editable_column_names: List[str]
+    show_header_filter: bool = True
     freeze_editable_columns: bool
     group_column_names: List[str]
     linked_records_count: int = 0

--- a/dss-plugin-visual-edit/webapps/visual-edit/backend.py
+++ b/dss-plugin-visual-edit/webapps/visual-edit/backend.py
@@ -61,7 +61,9 @@ de = DataEditor(
 )
 
 
-columns = get_columns_tabulator(de, webapp_config.freeze_editable_columns)
+columns = get_columns_tabulator(
+    de, webapp_config.show_header_filter, webapp_config.freeze_editable_columns
+)
 
 last_build_date_initial = ""
 last_build_date_ok = False

--- a/dss-plugin-visual-edit/webapps/visual-edit/webapp.json
+++ b/dss-plugin-visual-edit/webapps/visual-edit/webapp.json
@@ -149,6 +149,13 @@
             "type": "SEPARATOR"
         },
         {
+            "name": "show_header_filter",
+            "label": "Show header filter",
+            "description": "Show/hide header filters below each column header",
+            "type": "BOOLEAN",
+            "defaultValue": true
+        },
+        {
             "name": "freeze_editable_columns",
             "label": "Freeze editable columns",
             "description": "Freezing to the right-hand side",

--- a/dss-plugin-visual-edit/webapps/visual-edit/webapp.json
+++ b/dss-plugin-visual-edit/webapps/visual-edit/webapp.json
@@ -150,7 +150,7 @@
         },
         {
             "name": "show_header_filter",
-            "label": "Show header filter",
+            "label": "Show header filters",
             "description": "Show/hide header filters below each column header",
             "type": "BOOLEAN",
             "defaultValue": true


### PR DESCRIPTION
To test: either unselect the checkbox "Show header filters" or set the property `"show_header_filter": false/true` in the webapp.json