### PR TITLE
fix: Specify numpy<2.0.0 to resolve binary incompatibility

### DIFF
--- a/dss-plugin-visual-edit/code-env/python/spec/requirements.txt
+++ b/dss-plugin-visual-edit/code-env/python/spec/requirements.txt
@@ -2,3 +2,4 @@ dash>=2.4.0
 dash_extensions
 pydantic
 pandas==1.3.5
+numpy<2.0.0


### PR DESCRIPTION
   - Issue: Unspecified numpy version causes numpy.dtype size changed errors (binary incompatibility with numpy ≥2.0.0).

  -  Fix: Explicitly require `numpy<2.0.0` in requirements.txt.

   - Impact: Ensures stable plugin behavior with compatible numpy versions.