### PR TITLE
Dropdown / Linked Records: always include current cell value in list of options

### DIFF
--- a/dash_tabulator/assets/custom_tabulator.js
+++ b/dash_tabulator/assets/custom_tabulator.js
@@ -1,6 +1,3 @@
-filterFuncResultCount = 0
-addEventListener('keyup', (event) => { filterFuncResultCount = 0 });
-
 window.myNamespace = Object.assign({}, window.myNamespace, {
 
     tabulator: {
@@ -22,85 +19,9 @@ window.myNamespace = Object.assign({}, window.myNamespace, {
             },
         ],
 
-        // headerMenu: function() {
-        //     var menu = [];
-        //     var columns = this.getColumns();
-
-        //     for(let column of columns){
-
-        //         //create checkbox element using font awesome icons
-        //         let icon = document.createElement("i");
-        //         icon.classList.add("fas");
-        //         icon.classList.add(column.isVisible() ? "fa-check-square" : "fa-square");
-
-        //         //build label
-        //         let label = document.createElement("span");
-        //         let title = document.createElement("span");
-
-        //         title.textContent = " " + column.getDefinition().title;
-
-        //         label.appendChild(icon);
-        //         label.appendChild(title);
-
-        //         //create menu item
-        //         menu.push({
-        //             label:label,
-        //             action:function(e){
-        //                 //prevent menu closing
-        //                 e.stopPropagation();
-
-        //                 //toggle current column visibility
-        //                 column.toggle();
-
-        //                 //change menu item icon
-        //                 if(column.isVisible()){
-        //                     icon.classList.remove("fa-square");
-        //                     icon.classList.add("fa-check-square");
-        //                 }else{
-        //                     icon.classList.remove("fa-check-square");
-        //                     icon.classList.add("fa-square");
-        //                 }
-        //             }
-        //         });
-        //     }
-
-        //    return menu;
-        // },
-
-        searchFunc: function (term, values) { //search for exact matches
-            var matches = [];
-            if (term && term.length > 2) {
-                values.forEach(function (value) {
-                    //value - one of the values from the value property
-                    if (value.toString().startsWith(term)) {
-                        matches.push(value);
-                    }
-                });
-            }
-            return matches;
-        },
-
-        filterFunc: function (term, label, value, item) {
-            if (filterFuncResultCount >= 100) {
-                return false;
-            } else {
-                if (term !== null) {
-                    term = String(term).toLowerCase();
-                    if (term.length > 2 && label !== null && typeof label !== "undefined") {
-                        label = String(label).toLowerCase();
-                        if (label.startsWith(term)) {
-                            filterFuncResultCount += 1
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            }
-        },
-
         itemFormatter: function (label, value, item, element) {
-            //label - the text label for the item -> this would be the value of linked_ds_label
-            //value - the value for the item -> this would be the value of linked_ds_key -> we don't display it
+            //label - the text label for the item -> this would be the value of the linked dataset's label column
+            //value - the value for the item -> this would be the value of the linked dataset's primary key -> we don't display it
             //item - the original value object for the item
             //element - the DOM element for the item
 
@@ -198,25 +119,6 @@ window.myNamespace = Object.assign({}, window.myNamespace, {
             return container;
         },
 
-        paramLookup: function (cell, url_base) {
-            key = cell.getValue()
-            label = ""
-            // Assign value returned by GET request to url_base with parameter key, to label variable; in case connection fails, assign empty value to label
-            $.ajax({
-                url: url_base + "?key=" + key,
-                async: false,
-                success: function (result) {
-                    label = result
-                },
-                error: function (result) {
-                    label = ""
-                    console.log("Could not retrieve label from server")
-                }
-            });
-            d = {}
-            d[key] = label
-            return d
-        }
     }
 
 });

--- a/dss-plugin-visual-edit/python-lib/dataiku_utils.py
+++ b/dss-plugin-visual-edit/python-lib/dataiku_utils.py
@@ -78,6 +78,31 @@ def get_dataframe_filtered(ds_name, project_key, filter_column, filter_term, n_r
     return DataFrame(columns=rows[0], data=rows[1:]) if len(rows) > 0 else DataFrame()
 
 
+def get_linked_label(linked_record, key):
+    linked_ds_key = linked_record.ds_key
+    linked_ds_label = linked_record.ds_label
+    # Return label only if a label column is defined (and different from the key column)
+    if key != "" and linked_ds_label and linked_ds_label != linked_ds_key:
+        if linked_record.ds:
+            try:
+                label = linked_record.ds.get_cell_value_sql_query(
+                    linked_ds_key, key, linked_ds_label
+                )
+            except Exception:
+                return "Something went wrong fetching label of linked value.", 500
+        else:
+            linked_df = linked_record.df
+            if linked_df is None:
+                return "Something went wrong. Try restarting the backend.", 500
+            try:
+                label = linked_df.loc[key, linked_ds_label]
+            except Exception:
+                return label
+    else:
+        label = key
+    return label
+
+
 def is_sql_dataset(ds: Dataset) -> bool:
     # locationInfoType may not exist, for example for editable dataset.
     return ds.get_location_info().get("locationInfoType", "") == "SQL"

--- a/dss-plugin-visual-edit/python-lib/dataiku_utils.py
+++ b/dss-plugin-visual-edit/python-lib/dataiku_utils.py
@@ -107,6 +107,7 @@ def is_sql_dataset(ds: Dataset) -> bool:
     # locationInfoType may not exist, for example for editable dataset.
     return ds.get_location_info().get("locationInfoType", "") == "SQL"
 
+
 def is_bigquery_dataset(ds: Dataset) -> bool:
     location_info = ds.get_location_info()
     databaseType = location_info.get("info", "").get("databaseType", "")

--- a/dss-plugin-visual-edit/python-lib/tabulator_utils.py
+++ b/dss-plugin-visual-edit/python-lib/tabulator_utils.py
@@ -123,7 +123,7 @@ def __get_column_tabulator_editor__(t_type):
 ### Linked records
 
 
-def get_values_from_df(
+def get_formatted_items_from_linked_df(
     linked_df: DataFrame,
     key_col: str,
     label_col: str,
@@ -215,7 +215,7 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
     t_col = {}
     t_col["sorter"] = "string"
 
-    # Formatter: if a label column was provided, get the label value corresponding to the cell's value as primary key
+    # Formatter: if a label column was specified, get labels from the `label` endpoint and show them as user-friendly alternatives to the actual values (corresponding to primary keys of the linked dataset)
     if linked_ds_label_column != "" and linked_ds_label_column != linked_ds_key_column:
         t_col["formatter"] = assign(
             f"""

--- a/dss-plugin-visual-edit/python-lib/tabulator_utils.py
+++ b/dss-plugin-visual-edit/python-lib/tabulator_utils.py
@@ -248,12 +248,14 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
             """
         )
 
-    # Editor: use "list"
+    # Editor: use "list" for a dropdown
     t_col["editor"] = "list"
     t_col["editorParams"] = {
-        "valuesURL": "lookup/" + linked_ds_name,
         "clearable": True,
-        "maxWidth": True,
+        "elementAttributes": {"maxlength": "20"},
+        "emptyValue": None,
+        "placeholderLoading": "Loading List...",
+        "placeholderEmpty": "No Results Found",
         "autocomplete": True,
         "filterRemote": True,
         "filterDelay": 300,
@@ -261,7 +263,7 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
         "listOnEmpty": True,
         "freetext": False,
     }
-    # Editor item formatter: define if lookup columns were provided
+    # Editor: format items in the list if lookup columns were provided (in which case items are structured)
     if linked_ds_lookup_columns != []:
         t_col["editorParams"]["itemFormatter"] = __ns__("itemFormatter")
 

--- a/dss-plugin-visual-edit/python-lib/tabulator_utils.py
+++ b/dss-plugin-visual-edit/python-lib/tabulator_utils.py
@@ -236,8 +236,6 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
                         console.log("Could not retrieve label from server")
                     }}
                 }});
-                d = {{}}
-                d[key] = label
                 // if label is empty, return empty string
                 if (label == "") {{
                     return label

--- a/dss-plugin-visual-edit/python-lib/tabulator_utils.py
+++ b/dss-plugin-visual-edit/python-lib/tabulator_utils.py
@@ -261,6 +261,30 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
         "listOnEmpty": True,
         "freetext": False,
     }
+    # Editor: get values from the `lookup` endpoint
+    t_col["editorParams"]["valuesLookup"] = assign(
+        f"""
+            function(cell, filterTerm){{
+                url_base = "lookup/{linked_ds_name}"
+                key = cell.getValue()
+                optionsList = []
+                // Send GET request to `url_base`, with parameter `key`
+                // Assign returned value to the `label` variable; in case connection fails, assign empty value to label
+                $.ajax({{
+                    url: url_base + "?key=" + key + "&term=" + filterTerm,
+                    async: false,
+                    success: function(result){{
+                        optionsList = result
+                    }},
+                    error: function(result){{
+                        optionsList = []
+                        console.log("Could not retrieve options from server")
+                    }}
+                }});
+                return optionsList
+            }}
+            """
+    )
     # Editor: format items in the list if lookup columns were provided (in which case items are structured)
     if linked_ds_lookup_columns != []:
         t_col["editorParams"]["itemFormatter"] = __ns__("itemFormatter")

--- a/dss-plugin-visual-edit/python-lib/tabulator_utils.py
+++ b/dss-plugin-visual-edit/python-lib/tabulator_utils.py
@@ -215,7 +215,7 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
     t_col = {}
     t_col["sorter"] = "string"
 
-    # If a label column was provided, use a lookup formatter
+    # Formatter: if a label column was provided, get the label value corresponding to the cell's value as primary key
     if linked_ds_label_column != "" and linked_ds_label_column != linked_ds_key_column:
         t_col["formatter"] = assign(
             f"""
@@ -223,7 +223,8 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
                 url_base = "label/{linked_ds_name}"
                 key = cell.getValue()
                 label = ""
-                // Assign value returned by GET request to url_base with parameter key, to label variable; in case connection fails, assign empty value to label
+                // Send GET request to `url_base`, with parameter `key`
+                // Assign returned value to the `label` variable; in case connection fails, assign empty value to label
                 $.ajax({{
                     url: url_base + "?key=" + key,
                     async: false,
@@ -247,18 +248,20 @@ def __get_column_tabulator_linked_record__(de, linked_record_name):
             """
         )
 
-    # Use a list editor
+    # Editor: use "list"
     t_col["editor"] = "list"
     t_col["editorParams"] = {
+        "valuesURL": "lookup/" + linked_ds_name,
+        "clearable": True,
+        "maxWidth": True,
         "autocomplete": True,
         "filterRemote": True,
-        "valuesURL": "lookup/" + linked_ds_name,
         "filterDelay": 300,
+        "allowEmpty": False,
         "listOnEmpty": True,
-        "clearable": False,
-        "valuesLookupField": linked_record_name,
+        "freetext": False,
     }
-    # If lookup columns were provided, use an item formatter in the editor
+    # Editor item formatter: define if lookup columns were provided
     if linked_ds_lookup_columns != []:
         t_col["editorParams"]["itemFormatter"] = __ns__("itemFormatter")
 

--- a/dss-plugin-visual-edit/webapps/visual-edit/backend.py
+++ b/dss-plugin-visual-edit/webapps/visual-edit/backend.py
@@ -412,26 +412,7 @@ def label_endpoint(linked_ds_name):
     except Exception:
         return "Invalid key type.", 400
 
-    # Return label only if a label column is defined (and different from the key column)
-    if key != "" and linked_ds_label and linked_ds_label != linked_ds_key:
-        if linked_record.ds:
-            try:
-                label = linked_record.ds.get_cell_value_sql_query(
-                    linked_ds_key, key, linked_ds_label
-                )
-            except Exception:
-                return "Something went wrong fetching label of linked value.", 500
-        else:
-            linked_df = linked_record.df
-            if linked_df is None:
-                return "Something went wrong. Try restarting the backend.", 500
-            try:
-                label = linked_df.loc[key, linked_ds_label]
-            except Exception:
-                return label
-    else:
-        label = key
-    return label
+    return get_linked_label(linked_record, key)
 
 
 @server.route("/lookup/<linked_ds_name>", methods=["GET", "POST"])

--- a/dss-plugin-visual-edit/webapps/visual-edit/backend.py
+++ b/dss-plugin-visual-edit/webapps/visual-edit/backend.py
@@ -14,11 +14,16 @@ import logging
 from webapp.config.models import LinkedRecord
 import webapp.logging.setup  # noqa: F401 necessary to setup logging basicconfig before dataiku module sets a default config
 from datetime import datetime
+from pandas import concat
 from pandas.api.types import is_integer_dtype, is_float_dtype
 from commons import get_last_build_date, try_get_user_identifier
 from dash import Dash, Input, Output, State, dcc, html
 from dataiku.core.schema_handling import CASTERS
-from dataiku_utils import get_dataframe_filtered, client as dss_client
+from dataiku_utils import (
+    get_linked_dataframe_filtered,
+    get_linked_label,
+    client as dss_client,
+)
 from DataEditor import (
     EditFreezed,
     EditSuccess,
@@ -27,7 +32,7 @@ from DataEditor import (
     DataEditor,
 )
 from flask import Flask, jsonify, make_response, request
-from tabulator_utils import get_columns_tabulator, get_values_from_df
+from tabulator_utils import get_columns_tabulator, get_formatted_items_from_linked_df
 
 from webapp.config.loader import WebAppConfig
 
@@ -60,7 +65,7 @@ de = DataEditor(
     linked_records=webapp_config.linked_records,
     editschema_manual=webapp_config.editschema_manual,
     authorized_users=authorized_users,
-    freeze_edits=freeze_edits
+    freeze_edits=freeze_edits,
 )
 
 
@@ -420,25 +425,30 @@ def label_endpoint(linked_ds_name):
 @server.route("/lookup/<linked_ds_name>", methods=["GET", "POST"])
 def lookup_endpoint(linked_ds_name):
     """
-    Get label and lookup values in a linked dataset, matching a search term.
+    Get label and lookup values in a linked dataset
 
     This endpoint is used by Tabulator when editing a linked record. The values it returns are read by the `itemFormatter` function of the Tabulator table, which displays a dropdown list of linked records whose labels match the search term.
+
+    If a search term is provided, return a list of options that match this term. Otherwise, return a single option corresponding to the provided key.
+
+    Params:
+    - key: the primary key for the current linked record
+    - term: the search term to filter linked records
+
+    Returns: a list of matching options
     """
+
+    # Get request parameters
     if request.method == "POST":
+        key = request.get_json().get("key")
         term = request.get_json().get("term")
     else:
+        key = request.args.get("key", "")
         term = request.args.get("term", "")
-    logging.info(
-        f"""Received a request for dataset "{linked_ds_name}", term "{term}" ({len(term)} characters)"""
-    )
-
     term = term.strip().lower()
-    if term != "":
-        n_results = (
-            10  # show a limited number of options when a search term is provided
-        )
-    else:
-        n_results = 1000  # show more options if no search term is provided
+    logging.info(
+        f"""Received a request to get options from linked dataset "{linked_ds_name}" matching key "{key}" or search term "{term}" ({len(term)} characters)"""
+    )
 
     # Find the linked record whose linked dataset is requested
     linked_record: LinkedRecord | None = None
@@ -448,20 +458,42 @@ def lookup_endpoint(linked_ds_name):
             break
     if linked_record is None:
         return "Unknown linked dataset.", 404
+
+    # Return data only when it's a linked dataset; if we've reached this point, it means that this is the case
+
     linked_ds_key = linked_record.ds_key
     linked_ds_label = linked_record.ds_label
     linked_ds_lookup_columns = linked_record.ds_lookup_columns
 
-    if linked_record.ds:
-        # Use the Dataiku API to filter the dataset
-        linked_df_filtered = get_dataframe_filtered(
-            linked_ds_name,
-            project_key,
-            linked_ds_label,
-            term,
-            n_results,
-        )
+    if term != "":
+        # when a search term is provided, show a limited number of options matching this term
+        n_options = 10
     else:
+        # otherwise, show many options to choose from
+        n_options = 1000
+
+    # Get a dataframe of the linked dataset filtered by the search term or the key
+    linked_df_filtered = get_linked_dataframe_filtered(
+        linked_record=linked_record,
+        project_key=project_key,
+        filter_term=term,
+        n_results=n_options,
+    )
+
+    # when a key is provided, make sure to include an option corresponding to this key
+    # if not already the case, get the label for this key and use it as search term to filter the linked dataframe
+    if key != "":
+        linked_row = linked_df_filtered[linked_df_filtered[linked_ds_key] == key]
+        if linked_row.empty:
+            label = get_linked_label(linked_record, key).lower()
+            linked_row = get_linked_dataframe_filtered(
+                linked_record=linked_record,
+                project_key=project_key,
+                filter_term=label,
+                n_results=1,
+            )
+            linked_df_filtered = concat([linked_row, linked_df_filtered])
+
     editor_values_param = get_formatted_items_from_linked_df(
         linked_df=linked_df_filtered,
         key_col=linked_ds_key,


### PR DESCRIPTION
Motivations:
- Users occasionally click on cells of "linked record" columns to show the rich dropdown’s view of lookup values. They use this to decide whether to validate the row or not. For instance, in Medical Report Analyzer, they click on a cell of the "Mapped ICD10CM code" column to see the code description.
- However, when there are many records in the Linked Dataset (e.g., 110K) and no search term is entered, the dropdown loads the first 1K options only. As a result, the cell's current value often does not appear in the dropdown's list.
- When the user cannot find what they were looking for, they click out of the dropdown. When doing that, Tabulator tries to be nice by saving the dropdown's current selection. If the current value isn't in the list of options, the current selection is none, so this empties out the cell (even if the “allowEmpty” option is set to False in Tabulator)!
- As a result, when a value pre-existed and the user clicked on the cell, then out of the dropdown, the value appeared to be “lost”. This also gave the illusion that values could be removed with Visual Edit (which isn’t possible: when reloading the page, the value is still there).

Details on Tabulator’s behavior:
- When clicking a cell of the Mapped ICD10CM code column, Tabulator shows a search bar and prepares a dropdown with matching options.
- To get the matching options, it sends an Ajax request to the Flask backend (/lookup endpoint) along with the search term.
- Initially, this search term is empty. In that case, the backend sends back the first 1,000 records of the Linked Dataset.
- When Tabulator receives the list of options, if this list contains the current value of the cell, it will appear as automatically selected and the search bar will be automatically populated accordingly.
- Otherwise, nothing is selected and the search bar stays empty.

What we implemented in this PR:
- Included the current cell value in the Ajax request to /lookup sent by Tabulator’s “list” editor (defined in tabulator_utils.py)
- Used this value in the implementation of backend.py > lookup_endpoint() so the backend can make sure to include the corresponding label and lookup columns in the list of options.